### PR TITLE
Proper signing of boolean values

### DIFF
--- a/src/Crypto.php
+++ b/src/Crypto.php
@@ -114,6 +114,8 @@ class Crypto {
 					$ret,
 					self::createSignatureBaseRecursion($val, $depthCheck + 1)
 				);
+			} elseif (is_bool($val)) {
+				$ret[] = $val ? 'true' : 'false';
 			} else {
 				$ret[] = $val;
 			}


### PR DESCRIPTION
Currently method \OndraKoupil\Csob\Crypto::createSignatureBaseFromArray is returning "RETEZEC_ZPRAVY" with booleans converted to "0" and "1" (instead "false" and "true") which will result in incorrect signature and response code 400 from csob GW.

There is no boolean parameter except in "/payment/init" request ("closePayment") which is signed correctly by \OndraKoupil\Csob\Payment::signAndExport method. Now im implementing /applepay/init which is containing boolean parameter "closePayment" as well and Im using \OndraKoupil\Csob\Client::customRequest method for that.