### PR TITLE
returning customer - merchantData not mandatory

### DIFF
--- a/dist/csob-client.php
+++ b/dist/csob-client.php
@@ -1471,7 +1471,7 @@ class Client {
 			"resultMessage",
 			"paymentStatus",
 			"?authCode",
-			"merchantData",
+			"?merchantData",
 			// "signature"
 		);
 
@@ -1503,9 +1503,9 @@ class Client {
 		}
 
 		$mess = "Returning customer: payId ".$input["payId"].", authCode " . (isset($input["authCode"]) ? $input["authCode"] : '(not set)') . ", payment status ".$input["paymentStatus"];
-		if ($input["merchantData"]) {
-			$mess .= ", merchantData ".$input["merchantData"];
-		}
+        if(array_key_exists("merchantData", $input)){
+            $mess .= ", merchantData ".$input["merchantData"];
+        }
 		$this->writeToLog($mess);
 
 		return $input;


### PR DESCRIPTION
In API 1.9 it may happen that `payment/status` returns a payload with parameter a `actions.authenticate.browserChallenge` which contains `endpoint` that needs to be shown a customer. After challenge is completed by the customer, the browser redirects the customer to `returnUrl` which we provided in payload sent to `googlepay/init`.

At the `returnUrl` we call `$client->receiveReturningCustomer()`. In this method is expected parameter `merchantData`. But challenge url does not provides it therefore I think it shouldn't be required by the method.

Example of payload i received as `$_GET` from challenge URL.

```json
{
"payId":"266393e74334@HI",
"dttm":"20220920141236",
"resultCode":"0",
"resultMessage":"OK",
"paymentStatus":"7",
"authCode":"626678",
"signature":"aJHCZLtAWzWAAElrGjjXPmoqCfjEHza/6alw8IKawij5QveG8LT2SQEITc7m7DZFg4HO2qn0+oq0FG63R09TMzZjjabxuxH6jMR5/f+4ItFFkZpvc4YWCTp52Esh77ZQw1UG5qEFZEt9ckxKSmY2QxFsqrL6iexBxlQAY0ITb/uVaujCMoqN1UW3vBv1bg3xPnXEfOgSbNP/LRJOnySXVD5Jrd2aXjjQ9YcGYqugFkjpixbcc9ZFV5NQFgsNXdFyudxfNCI32D7RnaUw+z7oOjBHdyGNwy8K0KIo+UA9HrcCgzcUB7RV8eXxqmgXDUbLc36eehC8fQNXLZgJ3ptdGg=="
}
```