### PR TITLE
PHP 8.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ondrakoupil/tools": "~0.0.5",
         "ext-openssl": "*",
 		"ext-curl": "*",
-        "php": ">=5.4.8"
+        "php": ">=7.4"
     },
     "require-dev": {
         "nette/tester": "1.7.2",

--- a/dist/csob-client.php
+++ b/dist/csob-client.php
@@ -2192,9 +2192,8 @@ class Payment {
 	 * Leave empty if you don't want to use some features relying on knowing
 	 * customer ID.
 	 *
-	 * @var string
 	 */
-	public $customerId;
+	public string $customerId = '';
 
 	/**
 	 * Language of the gateway. Default is "CZ".
@@ -2298,7 +2297,7 @@ class Payment {
 	 * @param string $customerId
 	 * @param bool|null $oneClickPayment
 	 */
-	function __construct($orderNo = '', $merchantData = null, $customerId = null, $oneClickPayment = null) {
+	function __construct($orderNo = '', $merchantData = null, $customerId = '', $oneClickPayment = null) {
 		$this->orderNo = $orderNo;
 
 		if ($merchantData) {

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -114,9 +114,8 @@ class Payment {
 	 * Leave empty if you don't want to use some features relying on knowing
 	 * customer ID.
 	 *
-	 * @var string
 	 */
-	public $customerId;
+	public string $customerId = '';
 
 	/**
 	 * Language of the gateway. Default is "CZ".
@@ -220,7 +219,7 @@ class Payment {
 	 * @param string $customerId
 	 * @param bool|null $oneClickPayment
 	 */
-	function __construct($orderNo = '', $merchantData = null, $customerId = null, $oneClickPayment = null) {
+	function __construct($orderNo = '', $merchantData = null, $customerId = '', $oneClickPayment = null) {
 		$this->orderNo = $orderNo;
 
 		if ($merchantData) {


### PR DESCRIPTION
Parameter customerId has to be string to work in Strings::shorten (and other string functions, for example trim , strip_tags, ...) 